### PR TITLE
Fix parsing of watch files with comments before entries and blank lin…

### DIFF
--- a/src/lex.rs
+++ b/src/lex.rs
@@ -33,7 +33,7 @@ pub(crate) fn lex(text: &str) -> Vec<(SyntaxKind, String)> {
             (tok(EQUALS), r"="),
             (tok(COMMA), r","),
             (tok(NEWLINE), r"\n"),
-            (tok(WHITESPACE), r"\s+"),
+            (tok(WHITESPACE), r"[ \t\r]+"),
             (tok(COMMENT), r"#[^\n]*"),
         ])
         .build();


### PR DESCRIPTION
…es between entries

- parse_watch_entry() would stop at the first NEWLINE after skip_ws(), which meant a comment line before an entry caused that entry (and all subsequent ones) to be silently dropped. The fix loops over leading blank lines and comment-only lines before starting each entry. Closes: #1128319

- The WHITESPACE lexer regex matched \n via \s+, causing a blank line between two entries to be consumed as WHITESPACE inside the first entry's field loop, making the second entry appear as version-policy/script fields of the first. Fixed by changing WHITESPACE to [ \t\r]+ so newlines are always NEWLINE tokens.

- After the entry-parsing loop, any remaining unconsumed tokens were silently discarded. They are now placed in an ERROR node, ensuring the CST always covers the full input (to_string() round-trips back to the original).